### PR TITLE
Skip all installed packages with same short name

### DIFF
--- a/src/usr/sbin/sbopkg
+++ b/src/usr/sbin/sbopkg
@@ -2133,7 +2133,7 @@ add_item_to_queue() {
         # false match when running 'sbopkg -k -i queue' because 'foo' and
         # 'libfoo' matched
         INSTALLED=$(ls -1 /var/lib/pkgtools/packages/ |
-            grep "^$APP-[^-]*-[^-]*-[^-]*$REPO_TAG$")
+            grep "^$APP-[^-]*-[^-]*-[^-]*$")
         if [[ -n $INSTALLED ]]; then
             VERSION=$(sed 's:^.*-\([^-]*\)-[^-]*-[^-]*$:\1:'<<<$INSTALLED)
             if [[ -e $UPDATELIST ]]; then


### PR DESCRIPTION
Currently running sbopkg -k -i queue skips 'foo'' only if foo's full name ends in $REPO_TAG.
Remove this restriction to avoid installing a second 'foo', which can lead to break packages already installed also depending on 'foo' if both 'foo' do not have the same content.